### PR TITLE
Consistently handle pointer on .btn mouseover

### DIFF
--- a/css/css.css
+++ b/css/css.css
@@ -76,6 +76,7 @@ h1 {
   font-size: 1rem;
   padding: 0.8rem 1.4rem 0.8rem 1.4rem;
   border: solid #09161f 0.1rem;
+  cursor: pointer;
 }
 
 .btn, .again a {


### PR DESCRIPTION
Sorry for the drive-by PR, but I saw it when you linked to it [here](https://twitter.com/ablwr/status/942465914137731073) and loved it, but one tiny inconsistency bugged me: the `a` tag picked up `cursor: pointer` when it was in the "again" state but not on initial "get a reading" state. This just makes it the cursor display explicit without adding an empty `href` element.